### PR TITLE
release: restructure project and prepare NuGet packaging

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+
+
+# Her kan der laves custom rules for solution
+# Eksempel:
+
+
+#root = true
+
+#[*.cs]
+#indent_style = space
+#indent_size = 4
+#insert_final_newline = true
+#dotnet_sort_system_directives_first = true
+#dotnet_separate_import_directive_groups = true
+#dotnet_style_qualification_for_field = false:suggestion
+#csharp_new_line_before_open_brace = all

--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,79 @@
 #dotnet_separate_import_directive_groups = true
 #dotnet_style_qualification_for_field = false:suggestion
 #csharp_new_line_before_open_brace = all
+
+[*.{cs,vb}]
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers = 
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers = 
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers = 
+
+# Naming styles
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix = 
+dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+tab_width = 4
+indent_size = 4
+end_of_line = crlf
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+
+[*.cs]
+csharp_indent_labels = one_less_than_current
+csharp_using_directive_placement = outside_namespace:silent
+csharp_prefer_simple_using_statement = true:suggestion
+csharp_prefer_braces = true:silent
+csharp_style_namespace_declarations = block_scoped:silent
+csharp_style_prefer_method_group_conversion = true:silent
+csharp_style_prefer_top_level_statements = true:silent
+csharp_style_prefer_primary_constructors = true:suggestion
+csharp_prefer_system_threading_lock = true:suggestion
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = false:silent
+csharp_space_around_binary_operators = before_and_after

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -77,3 +77,15 @@ jobs:
       with:
         name: calculator-app
         path: ./publish
+
+
+
+    # Nuget Package
+    - name: Pack NuGet package
+      run: dotnet pack ./src/CalculatorLib/CalculatorLib.csproj -c Release -o ./nupkg
+
+    - name: Upload NuGet package
+      uses: actions/upload-artifact@v4
+      with:
+        name: nuget-package
+        path: ./nupkg

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -23,9 +23,24 @@ jobs:
       - name: Build
         run: dotnet build --no-restore
 
-      - name: Test
-        run: dotnet test --no-build --verbosity normal
+      # Run tests and collect coverage
+      - name: Test with code coverage
+        run: dotnet test ./tests/CIDemoTest/CIDemoTest.csproj --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutput=./TestResults/coverage/ /p:CoverletOutputFormat=cobertura
 
+      # Generate a human-readable coverage report
+      - name: Generate coverage report
+        uses: danielpalme/ReportGenerator-GitHub-Action@5.1.9
+        with:
+          reports: './TestResults/coverage/coverage.cobertura.xml'
+          targetdir: 'coveragereport'
+          reporttypes: 'HtmlInline;Cobertura'
+
+      # Upload the report as an artifact
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coveragereport
 
   publish:
     needs: build
@@ -48,25 +63,3 @@ jobs:
       with:
         name: calculator-app
         path: ./publish
-
-
-
-
-    # Run tests and collect coverage
-    - name: Test with code coverage
-      run: dotnet test ./tests/CIDemoTest/CIDemoTest.csproj --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutput=./TestResults/coverage/ /p:CoverletOutputFormat=cobertura
-
-    # Generate a human-readable coverage report
-    - name: Generate coverage report
-      uses: danielpalme/ReportGenerator-GitHub-Action@5.1.9
-      with:
-        reports: './TestResults/coverage/coverage.cobertura.xml'
-        targetdir: 'coveragereport'
-        reporttypes: 'HtmlInline;Cobertura'
-
-    # Upload the report as an artifact
-    - name: Upload coverage report
-      uses: actions/upload-artifact@v4
-      with:
-        name: coverage-report
-        path: coveragereport

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches: [main]
 
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -22,6 +23,8 @@ jobs:
 
       - name: Build
         run: dotnet build --no-restore
+
+
 
       # Run tests and collect coverage
       - name: Test with code coverage
@@ -41,6 +44,17 @@ jobs:
         with:
           name: coverage-report
           path: coveragereport
+
+
+
+      # Statisk kodeanalyse
+      - name: Install dotnet format
+        run: dotnet tool install -g dotnet-format
+
+      - name: Run code analysis
+        run: dotnet format --verify-no-changes --verbosity diagnostic
+
+
 
   publish:
     needs: build

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -25,7 +25,7 @@ jobs:
 
       # Run tests and collect coverage
       - name: Test with code coverage
-        run: dotnet test ./tests/CIDemoTest/CIDemoTest.csproj --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutput=./TestResults/coverage/ /p:CoverletOutputFormat=cobertura
+        run: dotnet test ./tests/CIDemoTest/CIDemoTest.csproj --collect:"XPlat Code Coverage" --verbosity normal -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura
 
       # Generate a human-readable coverage report
       - name: Generate coverage report

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Generate coverage report
         uses: danielpalme/ReportGenerator-GitHub-Action@5.1.9
         with:
-          reports: './TestResults/coverage/coverage.cobertura.xml'
+          reports: '**/coverage.cobertura.xml'
           targetdir: 'coveragereport'
           reporttypes: 'HtmlInline;Cobertura'
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -48,3 +48,25 @@ jobs:
       with:
         name: calculator-app
         path: ./publish
+
+
+
+
+    # Run tests and collect coverage
+    - name: Test with code coverage
+      run: dotnet test ./tests/CIDemoTest/CIDemoTest.csproj --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutput=./TestResults/coverage/ /p:CoverletOutputFormat=cobertura
+
+    # Generate a human-readable coverage report
+    - name: Generate coverage report
+      uses: danielpalme/ReportGenerator-GitHub-Action@5.1.9
+      with:
+        reports: './TestResults/coverage/coverage.cobertura.xml'
+        targetdir: 'coveragereport'
+        reporttypes: 'HtmlInline;Cobertura'
+
+    # Upload the report as an artifact
+    - name: Upload coverage report
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-report
+        path: coveragereport

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -26,3 +26,25 @@ jobs:
       - name: Test
         run: dotnet test --no-build --verbosity normal
 
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+  
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 6.0.x
+
+    - name: Publish
+      run: dotnet publish -c Release -o ./publish
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: calculator-app
+        path: ./publish

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
 
     - name: Publish
       run: dotnet publish -c Release -o ./publish

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -51,7 +51,10 @@ jobs:
       - name: Install dotnet format
         run: dotnet tool install -g dotnet-format
 
-      - name: Run code analysis
+      - name: Fix code formatting issues
+        run: dotnet format --verbosity diagnostic
+
+      - name: Verify no changes
         run: dotnet format --verify-no-changes --verbosity diagnostic
 
 

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,20 @@
+name: Auto-version
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Required to access git history and tags
+
+      - name: Bump version and push tag
+        uses: anothrNick/github-tag-action@1.36.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WITH_V: true             # Tag format will be v1.2.3
+          DEFAULT_BUMP: patch      # Can be 'patch', 'minor', or 'major'

--- a/CIDemo.sln
+++ b/CIDemo.sln
@@ -3,24 +3,44 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.13.35931.197
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CIDemo", "src\CIDemo\CIDemo.csproj", "{0BD2E8DF-B1FC-C63C-5007-EEB91A9C755F}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CIDemoTest", "tests\CIDemoTest\CIDemoTest.csproj", "{E51B5240-63B8-99C6-8E47-0792DE6E8640}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CalculatorLib", "src\CalculatorLib\CalculatorLib.csproj", "{8A8B526C-CF63-D9EE-7553-29E136D19995}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{0BD2E8DF-B1FC-C63C-5007-EEB91A9C755F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0BD2E8DF-B1FC-C63C-5007-EEB91A9C755F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0BD2E8DF-B1FC-C63C-5007-EEB91A9C755F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{0BD2E8DF-B1FC-C63C-5007-EEB91A9C755F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{E51B5240-63B8-99C6-8E47-0792DE6E8640}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E51B5240-63B8-99C6-8E47-0792DE6E8640}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E51B5240-63B8-99C6-8E47-0792DE6E8640}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E51B5240-63B8-99C6-8E47-0792DE6E8640}.Debug|x64.Build.0 = Debug|Any CPU
+		{E51B5240-63B8-99C6-8E47-0792DE6E8640}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E51B5240-63B8-99C6-8E47-0792DE6E8640}.Debug|x86.Build.0 = Debug|Any CPU
 		{E51B5240-63B8-99C6-8E47-0792DE6E8640}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E51B5240-63B8-99C6-8E47-0792DE6E8640}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E51B5240-63B8-99C6-8E47-0792DE6E8640}.Release|x64.ActiveCfg = Release|Any CPU
+		{E51B5240-63B8-99C6-8E47-0792DE6E8640}.Release|x64.Build.0 = Release|Any CPU
+		{E51B5240-63B8-99C6-8E47-0792DE6E8640}.Release|x86.ActiveCfg = Release|Any CPU
+		{E51B5240-63B8-99C6-8E47-0792DE6E8640}.Release|x86.Build.0 = Release|Any CPU
+		{8A8B526C-CF63-D9EE-7553-29E136D19995}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8A8B526C-CF63-D9EE-7553-29E136D19995}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8A8B526C-CF63-D9EE-7553-29E136D19995}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8A8B526C-CF63-D9EE-7553-29E136D19995}.Debug|x64.Build.0 = Debug|Any CPU
+		{8A8B526C-CF63-D9EE-7553-29E136D19995}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8A8B526C-CF63-D9EE-7553-29E136D19995}.Debug|x86.Build.0 = Debug|Any CPU
+		{8A8B526C-CF63-D9EE-7553-29E136D19995}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8A8B526C-CF63-D9EE-7553-29E136D19995}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8A8B526C-CF63-D9EE-7553-29E136D19995}.Release|x64.ActiveCfg = Release|Any CPU
+		{8A8B526C-CF63-D9EE-7553-29E136D19995}.Release|x64.Build.0 = Release|Any CPU
+		{8A8B526C-CF63-D9EE-7553-29E136D19995}.Release|x86.ActiveCfg = Release|Any CPU
+		{8A8B526C-CF63-D9EE-7553-29E136D19995}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ![Build Status](https://github.com/KenHSo/CIDemo-Kenneth/actions/workflows/build-test.yml/badge.svg)
+![Code Coverage](https://img.shields.io/badge/coverage-dynamic-lightgrey?labelColor=grey&color=blue&label=Coverage)
 
 # CIDemo-Kenneth
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![Version](https://img.shields.io/github/v/tag/KenHSo/CIDemo-Kenneth?label=version)
 
 
+
 # CIDemo-Kenneth
 
 Opgave uge 15 - introduktion til CI/CD

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ![Build Status](https://github.com/KenHSo/CIDemo-Kenneth/actions/workflows/build-test.yml/badge.svg)
 ![Code Coverage](https://img.shields.io/badge/coverage-dynamic-lightgrey?labelColor=grey&color=blue&label=Coverage)
+![Version](https://img.shields.io/github/v/tag/KenHSo/CIDemo-Kenneth?label=version)
+
 
 # CIDemo-Kenneth
 

--- a/src/CIDemo/Calculator.cs
+++ b/src/CIDemo/Calculator.cs
@@ -20,10 +20,22 @@ public class Calculator : ICalculator
     public double Divide(int a, int b)
     {
         if (b == 0)
-        {
             throw new DivideByZeroException("Cannot divide by zero.");
-        }
+
         return (double)a / b;
+    }
+
+    double ICalculator.Power(double a, double b)
+    {
+        return Math.Pow(a, b);
+    }
+
+    double ICalculator.SquareRoot(double a)
+    {
+        if (a < 0)
+            throw new ArgumentException("Cannot take the square root of a negative number.");
+
+        return Math.Sqrt(a);
     }
 }
 

--- a/src/CIDemo/Calculator.cs
+++ b/src/CIDemo/Calculator.cs
@@ -25,17 +25,63 @@ public class Calculator : ICalculator
         return (double)a / b;
     }
 
-    double ICalculator.Power(double a, double b)
+    public double Power(double a, double b)
     {
         return Math.Pow(a, b);
     }
 
-    double ICalculator.SquareRoot(double a)
+    public double SquareRoot(double a)
     {
         if (a < 0)
             throw new ArgumentException("Cannot take the square root of a negative number.");
 
         return Math.Sqrt(a);
+    }
+
+    public double Sin(double angleInRadians)
+    {
+        return Math.Sin(angleInRadians);
+    }
+
+    public double Cos(double angleInRadians)
+    {
+        return Math.Cos(angleInRadians);
+    }
+
+    public double Tan(double angleInRadians)
+    {
+        return Math.Tan(angleInRadians);
+    }
+
+    public double Log(double value)
+    {
+        if (value <= 0)
+            throw new ArgumentException("Logarithm undefined for non-positive values.");
+        return Math.Log(value);
+    }
+
+    public double Factorial(int number)
+    {
+        if (number < 0)
+            throw new ArgumentException("Factorial is undefined for negative numbers.");
+        if (number == 0 || number == 1)
+            return 1;
+
+        double result = 1;
+        for (int i = 2; i <= number; i++)
+            result *= i;
+
+        return result;
+    }
+
+    public double DegreesToRadians(double degrees)
+    {
+        return degrees * (Math.PI / 180);
+    }
+
+    public double RadiansToDegrees(double radians)
+    {
+        return radians * (180 / Math.PI);
     }
 }
 

--- a/src/CIDemo/ICalculator.cs
+++ b/src/CIDemo/ICalculator.cs
@@ -5,5 +5,7 @@ public interface ICalculator
         int Add(int a, int b); // Adds two integers
         int Subtract(int a, int b); // Subtracts two integers
         int Multiply(int a, int b); // Multiplies two integers
-        double Divide(int a, int b); // Divides two integers, returns a double  
+        double Divide(int a, int b); // Divides two integers, returns a double
+        double Power(double a, double b);
+        double SquareRoot(double a); 
 }

--- a/src/CIDemo/ICalculator.cs
+++ b/src/CIDemo/ICalculator.cs
@@ -7,5 +7,13 @@ public interface ICalculator
         int Multiply(int a, int b); // Multiplies two integers
         double Divide(int a, int b); // Divides two integers, returns a double
         double Power(double a, double b);
-        double SquareRoot(double a); 
+        double SquareRoot(double a);
+        double Sin(double angleInRadians);
+        double Cos(double angleInRadians);
+        double Tan(double angleInRadians);
+        double Log(double value);
+        double Factorial(int number);
+        double DegreesToRadians(double degrees);
+        double RadiansToDegrees(double radians);
+
 }

--- a/src/CIDemo/Program.cs
+++ b/src/CIDemo/Program.cs
@@ -1,2 +1,0 @@
-﻿// See https://aka.ms/new-console-template for more information
-Console.WriteLine("Hello, World!");

--- a/src/CalculatorLib/Calculator.cs
+++ b/src/CalculatorLib/Calculator.cs
@@ -1,4 +1,4 @@
-﻿namespace CIDemo;
+﻿namespace CalculatorLibrary;
 
 public class Calculator : ICalculator
 {

--- a/src/CalculatorLib/CalculatorLib.csproj
+++ b/src/CalculatorLib/CalculatorLib.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/CalculatorLib/CalculatorLib.csproj
+++ b/src/CalculatorLib/CalculatorLib.csproj
@@ -1,9 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+
+		<PackageId>KenHSo.Calculator</PackageId>
+		<Version>1.0.0</Version>
+		<Authors>KenHSo</Authors>
+		<Description>En simpel lommeregner-pakke</Description>
+		<PackageTags>calculator;math;ci-cd</PackageTags>
+	</PropertyGroup>
 
 </Project>

--- a/src/CalculatorLib/ICalculator.cs
+++ b/src/CalculatorLib/ICalculator.cs
@@ -2,18 +2,18 @@
 
 public interface ICalculator
 {
-        int Add(int a, int b); // Adds two integers
-        int Subtract(int a, int b); // Subtracts two integers
-        int Multiply(int a, int b); // Multiplies two integers
-        double Divide(int a, int b); // Divides two integers, returns a double
-        double Power(double a, double b);
-        double SquareRoot(double a);
-        double Sin(double angleInRadians);
-        double Cos(double angleInRadians);
-        double Tan(double angleInRadians);
-        double Log(double value);
-        double Factorial(int number);
-        double DegreesToRadians(double degrees);
-        double RadiansToDegrees(double radians);
+    int Add(int a, int b); // Adds two integers
+    int Subtract(int a, int b); // Subtracts two integers
+    int Multiply(int a, int b); // Multiplies two integers
+    double Divide(int a, int b); // Divides two integers, returns a double
+    double Power(double a, double b);
+    double SquareRoot(double a);
+    double Sin(double angleInRadians);
+    double Cos(double angleInRadians);
+    double Tan(double angleInRadians);
+    double Log(double value);
+    double Factorial(int number);
+    double DegreesToRadians(double degrees);
+    double RadiansToDegrees(double radians);
 
 }

--- a/src/CalculatorLib/ICalculator.cs
+++ b/src/CalculatorLib/ICalculator.cs
@@ -1,4 +1,4 @@
-﻿namespace CIDemo;
+﻿namespace CalculatorLibrary;
 
 public interface ICalculator
 {

--- a/tests/CIDemoTest/CIDemoTest.csproj
+++ b/tests/CIDemoTest/CIDemoTest.csproj
@@ -10,7 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />

--- a/tests/CIDemoTest/CIDemoTest.csproj
+++ b/tests/CIDemoTest/CIDemoTest.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\CIDemo\CIDemo.csproj" />
+	  <ProjectReference Include="..\..\src\CalculatorLib\CalculatorLib.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/CIDemoTest/CalculatorTests.cs
+++ b/tests/CIDemoTest/CalculatorTests.cs
@@ -1,7 +1,7 @@
-using CalculatorLibrary; 
+using CalculatorLibrary;
 
 namespace CIDemoTest
-{  
+{
     public class CalculatorTests
     {
         private readonly ICalculator _calculator;

--- a/tests/CIDemoTest/CalculatorTests.cs
+++ b/tests/CIDemoTest/CalculatorTests.cs
@@ -93,6 +93,32 @@ namespace CIDemoTest
             // Act & Assert
             Assert.Throws<DivideByZeroException>(() => _calculator.Divide(num1, num2));
         }
+
+        /// <summary>
+        /// Tests the Power method of the Calculator class with positive inputs.
+        /// </summary>
+        [Fact]
+        public void Power_ShouldReturnCorrectResult_WhenGivenBaseAndExponent()
+        {
+            // Arrange
+            double baseValue = 2;
+            double exponent = 3;
+
+            // Act
+            double result = _calculator.Power(baseValue, exponent);
+
+            // Assert
+            Assert.Equal(8.0, result, 5); // 2^3 = 8, with precision tolerance
+        }
+
+        /// <summary>
+        /// Tests the SquareRoot method of the Calculator class with negative input.
+        /// </summary>
+        [Fact]
+        public void SquareRoot_NegativeInput_ThrowsException()
+        {
+            Assert.Throws<ArgumentException>(() => _calculator.SquareRoot(-4));
+        }
     }
 
 }

--- a/tests/CIDemoTest/CalculatorTests.cs
+++ b/tests/CIDemoTest/CalculatorTests.cs
@@ -1,4 +1,4 @@
-using CIDemo;
+using CalculatorLibrary; 
 
 namespace CIDemoTest
 {  

--- a/tests/CIDemoTest/CalculatorTests.cs
+++ b/tests/CIDemoTest/CalculatorTests.cs
@@ -119,6 +119,102 @@ namespace CIDemoTest
         {
             Assert.Throws<ArgumentException>(() => _calculator.SquareRoot(-4));
         }
+
+        /// <summary>
+        /// Tests the Sin method of the Calculator class.
+        /// </summary>
+        [Fact]
+        public void Sin_ShouldReturnCorrectResult_WhenGivenRadians()
+        {
+            double radians = Math.PI / 2; // 90 degrees
+            double result = _calculator.Sin(radians);
+            Assert.Equal(1.0, result, 5); // Close to 1.0
+        }
+
+        /// <summary>
+        /// Tests the Cos method of the Calculator class.
+        /// </summary>
+        [Fact]
+        public void Cos_ShouldReturnCorrectResult_WhenGivenRadians()
+        {
+            double radians = Math.PI; // 180 degrees
+            double result = _calculator.Cos(radians);
+            Assert.Equal(-1.0, result, 5);
+        }
+
+        /// <summary>
+        /// Tests the Tan method of the Calculator class.
+        /// </summary>
+        [Fact]
+        public void Tan_ShouldReturnCorrectResult_WhenGivenRadians()
+        {
+            double radians = Math.PI / 4; // 45 degrees
+            double result = _calculator.Tan(radians);
+            Assert.Equal(1.0, result, 5);
+        }
+
+        /// <summary>
+        /// Tests the Log method of the Calculator class.
+        /// </summary>
+        [Fact]
+        public void Log_ShouldReturnCorrectResult_WhenGivenPositiveValue()
+        {
+            double value = Math.E;
+            double result = _calculator.Log(value);
+            Assert.Equal(1.0, result, 5); // ln(e) = 1
+        }
+
+        [Fact]
+        public void Log_ShouldThrowException_WhenGivenZeroOrNegative()
+        {
+            Assert.Throws<ArgumentException>(() => _calculator.Log(0));
+            Assert.Throws<ArgumentException>(() => _calculator.Log(-5));
+        }
+
+        /// <summary>
+        /// Tests the Factorial method of the Calculator class.
+        /// </summary>
+        [Fact]
+        public void Factorial_ShouldReturnCorrectResult_WhenGivenPositiveInteger()
+        {
+            int value = 5;
+            double result = _calculator.Factorial(value);
+            Assert.Equal(120, result);
+        }
+
+        [Fact]
+        public void Factorial_ShouldReturn1_WhenGivenZeroOrOne()
+        {
+            Assert.Equal(1, _calculator.Factorial(0));
+            Assert.Equal(1, _calculator.Factorial(1));
+        }
+
+        [Fact]
+        public void Factorial_ShouldThrowException_WhenGivenNegative()
+        {
+            Assert.Throws<ArgumentException>(() => _calculator.Factorial(-1));
+        }
+
+        /// <summary>
+        /// Tests radians and degree conversion.
+        /// </summary>
+        [Fact]
+        public void DegreesToRadians_ShouldConvertCorrectly()
+        {
+            double degrees = 180;
+            double result = _calculator.DegreesToRadians(degrees);
+            Assert.Equal(Math.PI, result, 5);
+        }
+
+        [Fact]
+        public void RadiansToDegrees_ShouldConvertCorrectly()
+        {
+            double radians = Math.PI;
+            double result = _calculator.RadiansToDegrees(radians);
+            Assert.Equal(180, result, 5);
+        }
+
+
     }
 
 }


### PR DESCRIPTION
## Summary

This release merges the refactoring into `main` and sets up NuGet packaging.

## What's Included

- Moved calculator code to `CalculatorLibrary`
- Updated test project references
- Added NuGet metadata and pack step to CI

## Why It Matters

- Prepares the codebase for packaging and reuse
- Enables future publishing to NuGet

## Next Steps

- Verify `.nupkg` is uploaded after merging
- Confirm pack step only runs on `main`
